### PR TITLE
Improve download location selection

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -12,6 +12,7 @@ get_latest_opam() {
   fi
 
   curl -s https://api.github.com/repos/ocaml/opam/releases/latest |
+    grep "browser_download_url" |
     grep "opam" |
     grep -- $platform |
     grep -v ".asc" |


### PR DESCRIPTION
Both "name" and "browser_download_url" were matched using the old
logic. However "name" doesn't result in a value url. wget ignores this
with a 'unable to resolve host address'.