### PR TITLE
Opam silence

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-eval $(env SHELL=$0 OPAMROOT=$ASDF_INSTALL_PATH $ASDF_INSTALL_PATH/$ASDF_INSTALL_VERSION/bin/opam config env --root=$ASDF_INSTALL_PATH)
+eval $(env SHELL=$0 OPAMROOT=$ASDF_INSTALL_PATH $ASDF_INSTALL_PATH/$ASDF_INSTALL_VERSION/bin/opam config env --root=$ASDF_INSTALL_PATH 2>/dev/null)

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-eval $(env SHELL=$0 $ASDF_INSTALL_PATH/$ASDF_INSTALL_VERSION/bin/opam config env --root=$ASDF_INSTALL_PATH)
+eval $(env SHELL=$0 OPAMROOT=$ASDF_INSTALL_PATH $ASDF_INSTALL_PATH/$ASDF_INSTALL_VERSION/bin/opam config env --root=$ASDF_INSTALL_PATH)


### PR DESCRIPTION
Silences the warning about the executable path and the note about the OPAMROOT